### PR TITLE
Fix strategies cognito scheme options

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = function() {
   this.options.auth.strategies = this.options.auth.strategies || {};
   this.options.auth.strategies.cognito =
     this.options.auth.strategies.cognito || {};
-  this.options.auth.strategies.cognito._scheme =
+  this.options.auth.strategies.cognito.scheme =
     "@sirdiego/nuxt-auth-cognito-scheme/CognitoAuthScheme";
 };
 


### PR DESCRIPTION
The `scheme` option seems not be overwriting correctly, to make your schema work I had to overwrite this option on `nuxt.config.js`

![image](https://user-images.githubusercontent.com/1767051/114135301-130de380-98d7-11eb-8047-47ddb1269c63.png)


* from : 
    `this.options.auth.strategies.cognito._scheme`

* to : 
    `this.options.auth.strategies.cognito.scheme`

Taking that away, your schema worked perfectly on my proyect.

Saludos